### PR TITLE
Retrieve unsplash image master 12

### DIFF
--- a/app/controllers/api/v1/images_controller.rb
+++ b/app/controllers/api/v1/images_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::ImagesController < ApplicationController
+  skip_before_action :authenticate_request
+
+  def show
+  end
+end

--- a/app/controllers/api/v1/images_controller.rb
+++ b/app/controllers/api/v1/images_controller.rb
@@ -2,9 +2,7 @@ class Api::V1::ImagesController < ApplicationController
   skip_before_action :authenticate_request
 
   def show
-    image_data = Api::V1::UnsplashService.new.random_photo_data
-    image = Api::V1::Image.new(image_data)
-    image_hash = Api::V1::ImageSerializer.new(image).serializable_hash
-    render json: image_hash
+    image = Api::V1::ImageGenerator.new(params[:query]).image_hash
+    render json: image
   end
 end

--- a/app/controllers/api/v1/images_controller.rb
+++ b/app/controllers/api/v1/images_controller.rb
@@ -2,5 +2,9 @@ class Api::V1::ImagesController < ApplicationController
   skip_before_action :authenticate_request
 
   def show
+    image_data = Api::V1::UnsplashService.new.random_photo_data
+    image = Api::V1::Image.new(image_data)
+    image_hash = Api::V1::ImageSerializer.new(image).serializable_hash
+    render json: image_hash
   end
 end

--- a/app/models/api/v1/image.rb
+++ b/app/models/api/v1/image.rb
@@ -1,6 +1,7 @@
 class Api::V1::Image
   attr_reader :id
   def initialize(unsplash_data)
+    @id = 176
     @thumb_size = unsplash_data["urls"]["thumb"]
     @small_size = unsplash_data["urls"]["small"]
     @regular_size = unsplash_data["urls"]["regular"]

--- a/app/models/api/v1/image.rb
+++ b/app/models/api/v1/image.rb
@@ -17,7 +17,7 @@ class Api::V1::Image
   end
 
   def unsplash_link
-    "https://unsplash.com/?utm_source=powdercast&utm_medium=referall"
+    "https://unsplash.com/?utm_source=powdercast&utm_medium=referral"
   end
 
   def sizes

--- a/app/models/api/v1/image.rb
+++ b/app/models/api/v1/image.rb
@@ -1,0 +1,34 @@
+class Api::V1::Image
+  attr_reader :id
+  def initialize(unsplash_data)
+    @thumb_size = unsplash_data["urls"]["thumb"]
+    @small_size = unsplash_data["urls"]["small"]
+    @regular_size = unsplash_data["urls"]["regular"]
+    @full_size = unsplash_data["urls"]["full"]
+    @raw_size = unsplash_data["urls"]["raw"]
+    @artist_link = unsplash_data["links"]["html"]
+    @artist_referral_link = artist_referral_link
+    @unsplash_link = unsplash_link
+  end
+
+  def artist_referral_link
+    "#{@artist_link}?utm_source=powdercast&utm_medium=referral"
+  end
+
+  def unsplash_link
+    "https://unsplash.com/?utm_source=powdercast&utm_medium=referall"
+  end
+
+  def sizes
+    { thumb_size: @thumb_size,
+      small_size: @small_size,
+      regular_size: @regular_size,
+      full_size: @full_size
+    }
+  end
+
+  def links
+    { artist_referral_link: @artist_referral_link,
+      unsplash_link: @unsplash_link }
+  end
+end

--- a/app/models/api/v1/image_generator.rb
+++ b/app/models/api/v1/image_generator.rb
@@ -1,0 +1,19 @@
+class Api::V1::ImageGenerator
+  def initialize(query)
+    @query = query
+  end
+
+  def image_hash
+    Api::V1::ImageSerializer.new(image).serializable_hash
+  end
+
+  private
+
+  def image
+    image_data ||= Api::V1::Image.new(unsplash_data)
+  end
+
+  def unsplash_data
+    unsplash_data ||= Api::V1::UnsplashService.new(@query).random_photo_data
+  end
+end

--- a/app/models/api/v1/snowcast.rb
+++ b/app/models/api/v1/snowcast.rb
@@ -4,6 +4,7 @@ class Api::V1::Snowcast
               :resort_name
 
   def initialize(ww_data = {}, ds_data = {}, resort)
+    @id = 512
     @resort_id = resort.id
     @resort_name = resort.name
 

--- a/app/serializers/api/v1/image_serializer.rb
+++ b/app/serializers/api/v1/image_serializer.rb
@@ -1,0 +1,4 @@
+class Api::V1::ImageSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :sizes, :links
+end

--- a/app/services/api/v1/unsplash_service.rb
+++ b/app/services/api/v1/unsplash_service.rb
@@ -1,4 +1,8 @@
 class Api::V1::UnsplashService
+  def initialize(query)
+    @query = query
+  end
+
   def random_photo_data
     JSON.parse(response('/photos/random').body)[0]
   end
@@ -6,7 +10,7 @@ class Api::V1::UnsplashService
   private
   def conn
     Faraday.new(url: "https://api.unsplash.com") do |faraday|
-      faraday.params["query"] = "ski,snowboard"
+      faraday.params["query"] = "#{@query}"
       faraday.params["count"] = 1
       faraday.params["client_id"] = ENV["unsplash_api_key"]
       faraday.adapter Faraday.default_adapter
@@ -16,5 +20,4 @@ class Api::V1::UnsplashService
   def response(url)
     conn.get(url)
   end
-
 end

--- a/app/services/api/v1/unsplash_service.rb
+++ b/app/services/api/v1/unsplash_service.rb
@@ -1,6 +1,6 @@
 class Api::V1::UnsplashService
   def random_photo_data
-    JSON.parse(response('/photos/random'))
+    JSON.parse(response('/photos/random').body)[0]
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   namespace :api do
     namespace :v1 do
+      get '/images', to: 'images#show'
       get '/snowcast', to: 'snowcast#show'
       resources :users, only: [:create]
     end

--- a/spec/requests/api/v1/images_request_spec.rb
+++ b/spec/requests/api/v1/images_request_spec.rb
@@ -3,8 +3,23 @@ require 'rails_helper'
 describe 'GET /api/v1/images?query=search_params' do
   it 'sends a random image' do
     search_params = "ski,snowboard"
+
     get "/api/v1/images?query=#{search_params}"
 
+    image = JSON.parse(response.body)
+
     expect(response).to be_successful
+    expect(image).to have_key("data")
+    expect(image["data"]).to have_key("id")
+    expect(image["data"]).to have_key("type")
+    expect(image["data"]).to have_key("attributes")
+    expect(image["data"]["attributes"]).to have_key("sizes")
+    expect(image["data"]["attributes"]["sizes"]).to have_key("thumb_size")
+    expect(image["data"]["attributes"]["sizes"]).to have_key("small_size")
+    expect(image["data"]["attributes"]["sizes"]).to have_key("regular_size")
+    expect(image["data"]["attributes"]["sizes"]).to have_key("full_size")
+    expect(image["data"]["attributes"]).to have_key("links")
+    expect(image["data"]["attributes"]["links"]).to have_key("artist_referral_link")
+    expect(image["data"]["attributes"]["links"]).to have_key("unsplash_link")
   end
 end

--- a/spec/requests/api/v1/images_request_spec.rb
+++ b/spec/requests/api/v1/images_request_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+describe 'GET /api/v1/images?query=search_params' do
+  it 'sends a random image' do
+    search_params = "ski,snowboard"
+    get "/api/v1/images?query=#{search_params}"
+
+    expect(response).to be_successful
+  end
+end


### PR DESCRIPTION
This adds tests & methods for the endpoint `api/v1/images?query=ski,snowboard`. Image data (different size links, artist referral link, & Unsplash link) is pulled for a single random image based on query keyword parameters, such as "ski,snowboard". This endpoint was made to be dynamic, in case different image keywords would be desired to be used in the future (such as "snow" or "Vail").

[X] All Tests Pass
[X] Code Runs Locally

 Image endpoint: 
<img width="1028" alt="11_6_image_endpoint" src="https://user-images.githubusercontent.com/36902512/48084951-3daf5b80-e1b6-11e8-9513-93b1f58e96ea.png">

Snowcast endpoint: 
<img width="986" alt="11_6_snowcast_endpoint" src="https://user-images.githubusercontent.com/36902512/48085466-93d0ce80-e1b7-11e8-9155-9dcfa59e4728.png">
