### PR TITLE
Rack cors middleware

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem 'simple_command' # for user authentication, instead of using private control
 gem 'bootsnap', '>= 1.1.0', require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-# gem 'rack-cors'
+gem 'rack-cors', require: 'rack/cors'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,7 @@ GEM
     public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.5)
+    rack-cors (1.0.2)
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -209,6 +210,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   pry
   puma (~> 3.11)
+  rack-cors
   rails (~> 5.2.1)
   rspec-rails
   shoulda-matchers

--- a/config.ru
+++ b/config.ru
@@ -3,3 +3,24 @@
 require_relative 'config/environment'
 
 run Rails.application
+
+use Rack::Cors do
+  allow do
+    origins 'localhost:3000', '127.0.0.1:3000',
+            /\Ahttp:\/\/192\.168\.0\.\d{1,3}(:\d+)?\z/
+            # regular expressions can be used here
+
+    resource '/file/list_all/', :headers => 'x-domain-token'
+    resource '/file/at/*',
+        methods: [:get, :post, :delete, :put, :patch, :options, :head],
+        headers: 'x-domain-token',
+        expose: ['Some-Custom-Response-Header'],
+        max_age: 600
+        # headers to expose
+  end
+
+  allow do
+    origins '*'
+    resource '/public/*', headers: :any, methods: :get
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,5 +35,13 @@ module Powderkeg
     config.api_only = true
     # For development, autoload lib folder
     config.autoload_paths << Rails.root.join('lib')
+
+    # Cross-origin resource sharign (CORS) config
+    config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        origins '*'
+        resource '*', headers: :any, methods: [:get, :post, :options]
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds [Rack CORS Middleware](https://github.com/cyu/rack-cors). Rack::Cors supports Cross-Origin Resource Sharing (CORS) for Rack compatible web apps. Most browsers block cross-domain HTTP requests. I am integrating my frontend, [a JavaScript single page app called Ski Meow](https://github.com/cyu/rack-cors), with my backend, [this PowderKeg API](https://powderkeg.herokuapp.com/). Because my frontend and backend are on different domains, I need to allow these requests using the rack-cors gem. 

This also configures CORS for a Rails 5 API.

[X] Code Runs Locally